### PR TITLE
Tweaked 720 and 1080 preset from slow to medium

### DIFF
--- a/downloadtranscoder.ps1
+++ b/downloadtranscoder.ps1
@@ -66,6 +66,7 @@ March 28, 2016 - added -turbo for h264/5 fast 1st pass and updated h265 2nd pass
      - added crf option for h265
      - removed "profile" from h265 as it's broken
 March 29th, 2016 - Tweaked CRF settings
+March 30th, 2016 - Tweaked h265 encode speed, slow just takes too long on my hardware -- eventually i'll create a settings file that users will have the ability to change this
 #>
 
 #Set Priority to Low
@@ -213,8 +214,8 @@ $ffmpegHEVC_720p1st = "-vcodec libx265 -preset fast -b:v 720k" # -x265-params `"
 $ffmpegHEVC_1080p2nd ="-vcodec libx265 -preset slow -b:v 1300k"  # -x265-params `"profile=high10`"   #.64 bits per pixel
 $ffmpegHEVC_1080p1st ="-vcodec libx265 -preset fast -b:v 1300k" #  -x265-params `"profile=high10`"   #.64 bits per pixel
 $ffmpegHEVC_480pcrf = "-vcodec libx265 -preset slow -x265-params crf=28" # -x265-params `"profile=high10`"
-$ffmpegHEVC_720pcrf = "-vcodec libx265 -preset slow -x265-params crf=27" # -x265-params `"profile=high10`"
-$ffmpegHEVC_1080pcrf ="-vcodec libx265 -preset slow -x265-params crf=26" #  -x265-params `"profile=high10`" 
+$ffmpegHEVC_720pcrf = "-vcodec libx265 -preset medium -x265-params crf=27" # -x265-params `"profile=high10`"
+$ffmpegHEVC_1080pcrf ="-vcodec libx265 -preset medium -x265-params crf=26" #  -x265-params `"profile=high10`" 
 
 $ffmpegacopy = "-acodec copy" 
 $ffmpeg2ch = "-acodec aac -ac 2 -ab 64k -strict -2"


### PR DESCRIPTION
Tweaked 720 and 1080 preset from slow to medium
- 1fps is just too slow encode speed
- will give user ability to specify with settings file in the future.
